### PR TITLE
Fix first run when server.properties missing

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -39,14 +39,12 @@ var serverjar = require('./nmc_modules/serverjar.js');
 // Set variables for the server(s)
 var current = 145;
 var dir = ".";
-var properties = [];
 var files = "";
 var usingfallback = false;
 var completelog = "";
+var srvprp;
 try { // If no error, server has been run before
     var serverOptions = JSON.parse(fs.readFileSync('server_files/properties.json', 'utf8'));
-    var srvprp = pr('server.properties'); // Get the original properties
-    var oldport = srvprp.get('server-port');
 
     if (serverOptions.firstrun) {
         console.log("Naviagte to http://localhost:" + serverOptions.port + " to set up NodeMC.");
@@ -57,7 +55,6 @@ try { // If no error, server has been run before
     //console.log(sf_web);
 } catch (e) { // If there is an error, copy server files!
     console.log(e);
-    var serverOptions = srvprp = null;
     console.log("Essential files not found! Please read the guide on Getting Started :)");
     console.log("Exiting...");
     process.exit(1);
@@ -139,6 +136,20 @@ app.use(morgan('common', {
 
 // App functions for various things
 
+function getServerProps(force) {
+    if (!force || (typeof srvprp !== "undefined" && srvprp !== null)) {
+        return srvprp;
+    } else {
+        try {
+            srvprp = pr("server.properties");
+        } catch (e) {
+            console.log(e);
+            srvprp = null;
+        }
+        return srvprp;
+    }
+}
+
 function checkAPIKey(key) {
     if (key == apikey) {
         return true;
@@ -176,19 +187,25 @@ function setport() { // Enforcing server properties set by host
     //console.log(oldport);
     //console.log(mcport);
     try {
-        // Here we set any minecraft server properties we need
-        fs.readFile('server.properties', 'utf8', function(err, data) {
-            if (err) {
-                return console.log(err);
-            }
-            var result = data.replace('server-port=' + oldport, 'server-port=' + mcport);
+		var props = getServerProps(); // Get the original properties
+		if (props !== null) {
+            var oldport = props.get('server-port');
+			// Here we set any minecraft server properties we need
+			fs.readFile('server.properties', 'utf8', function(err, data) {
+				if (err) {
+					return console.log(err);
+				}
+				var result = data.replace('server-port=' + oldport, 'server-port=' + mcport);
 
-            fs.writeFile('server.properties', result, 'utf8', function(err) {
-                if (err) return console.log(err);
-            });
-        });
-        srvprp = pr('server.properties'); // Get the new properties
+				fs.writeFile('server.properties', result, 'utf8', function(err) {
+					if (err) return console.log(err);
+				});
+			});
+			props = pr('server.properties'); // Get the new properties
         //console.log(oldport);
+        } else {
+            console.log("Failed to get the server properties!");
+        }
 
         fs.readFile('eula.txt', 'utf8', function(err, data) {
             if (err) {
@@ -433,14 +450,21 @@ app.post('/savefile', function(request, response) { // Save a POST'd file
 });
 
 app.get('/info', function(request, response) { // Return server info as JSON object
-    properties.push(srvprp.get('motd')); // message of the day
-    properties.push(srvprp.get('server-port')); // server port
-    properties.push(srvprp.get('white-list')); // if whitelist is on or off
-    properties.push(serverOptions['jar'] + ' ' + serverOptions['version']); // server jar version
-    properties.push(outsideip); // outside ip
-    properties.push(serverOptions['id']); // 
-    response.send(JSON.stringify(properties));
-    properties = []; // reset so we don't keep adding to it
+    var props = getServerProps();
+    var serverInfo = [];
+	if (props !== null) {
+		serverInfo.push(props.get('motd')); // message of the day
+		serverInfo.push(props.get('server-port')); // server port
+		serverInfo.push(props.get('white-list')); // if whitelist is on or off
+	} else {
+		serverInfo.push("Failed to get MOTD.");
+		serverInfo.push("Failed to get port.");
+		serverInfo.push(false);
+	}
+    serverInfo.push(serverOptions['jar'] + ' ' + serverOptions['version']); // server jar version
+    serverInfo.push(outsideip); // outside ip
+    serverInfo.push(serverOptions['id']); // 
+    response.send(JSON.stringify(serverInfo));
 });
 
 app.post('/restartserver', function(request, response) { // Restart server


### PR DESCRIPTION
Fix an exception being thrown on first run when the server.properties is
missing (the most likely cause of this is that a Minecraft server hasn't
yet been run in the directory NodeMC is being run from).
