### PR TITLE
Fix potential unresponsiveness with large log

### DIFF
--- a/server_files/web_files/dashboard/getlog.js
+++ b/server_files/web_files/dashboard/getlog.js
@@ -5,7 +5,7 @@ function getlogs() {
         $.get(
             "/log",
             function(log) {
-                $("#log").val(log);
+                $("#log").val(log.split("\n").slice(-500).join("\n"));
                 var textarea = document.getElementById('log');
                 textarea.scrollTop = textarea.scrollHeight;
             });


### PR DESCRIPTION
Only keep the last 500 lines in the log to reduce the chance of the page becoming unresponsive with a large log.
