### PR TITLE
Improve server restart logic

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -43,6 +43,8 @@ var files = "";
 var usingfallback = false;
 var completelog = "";
 var srvprp;
+var restartPending = false;
+
 try { // If no error, server has been run before
     var serverOptions = JSON.parse(fs.readFileSync('server_files/properties.json', 'utf8'));
 
@@ -171,16 +173,21 @@ function checkVersion() { // Check for updates
 }
 
 function restartserver() { // Restarting the server
-    serverSpawnProcess.stdin.write('say [NodeMC] Restarting server!\n');
+    if (!serverStopped) {
+        serverSpawnProcess.stdin.write('say [NodeMC] Restarting server!\n');
 
-    serverSpawnProcess.stdin.write('stop\n');
+        serverSpawnProcess.stdin.write('stop\n');
 
-    serverSpawnProcess.on("close", function() {
-        serverStopped = true;
+        serverSpawnProcess.on("close", function() {
+            serverStopped = true;
+            setport();
+
+            startServer();
+        });   
+    } else {
         setport();
-
         startServer();
-    });
+    }
 }
 
 function setport() { // Enforcing server properties set by host
@@ -240,6 +247,12 @@ function startServer() { // Start server process
     ]);
     serverSpawnProcess.stdout.on('data', log);
     serverSpawnProcess.stderr.on('data', log);
+    serverSpawnProcess.on('exit', function(code) {
+        serverStopped == true; // Server process has crashed or stopped
+        if (restartPending) {
+            startServer();
+        }
+    });
 }
 
 function log(data) { // Log (dump) server output to variable
@@ -364,6 +377,9 @@ app.post('/command', function(request, response) { // Send command to server
         var command = request.param('Body');
         if (command == "stop") {
             serverStopped = true;
+        } else if (command == "restart") {
+            serverStopped = true;
+            restartPending = true;
         }
         serverSpawnProcess.stdin.write(command + '\n');
 
@@ -522,6 +538,9 @@ process.on('exit', function(code) { // When it exits kill the server process too
 if (typeof serverSpawnProcess != "undefined") {
     serverSpawnProcess.on('exit', function(code) {
         serverStopped == true; // Server process has crashed or stopped
+        if (restartPending) {
+            startServer();
+        }
     });
 }
 process.stdout.on('error', function(err) {


### PR DESCRIPTION
- Restart the Minecraft server after it stops if the player has run
  /restart (though if they use /restart, they shouldn't set a restart
  script with it)
- Reattach the server process exit listener every time the server starts
- Don't try to stop the server if someone tries to restart the server
  from the dash and it has already stopped.
