### PR TITLE
Disable spell checking and autocorrection on dash

### DIFF
--- a/server_files/web_files/dashboard/index.html
+++ b/server_files/web_files/dashboard/index.html
@@ -57,7 +57,7 @@
             <span class="input-group-btn">
               <button class="btn btn-default" type="button">Execute</button>
             </span>
-            <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="text" class="form-control" id="command" name="Body" placeholder="command">
+            <input autocorrect="off" autocapitalize="off" spellcheck="false" type="text" class="form-control" id="command" name="Body" placeholder="command">
           </div>
         </form>
       </div>

--- a/server_files/web_files/dashboard/index.html
+++ b/server_files/web_files/dashboard/index.html
@@ -57,7 +57,7 @@
             <span class="input-group-btn">
               <button class="btn btn-default" type="button">Execute</button>
             </span>
-            <input autocorrect="off" autocapitalize="off" spellcheck="false" type="text" class="form-control" id="command" name="Body" placeholder="command">
+            <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="text" class="form-control" id="command" name="Body" placeholder="command">
           </div>
         </form>
       </div>

--- a/server_files/web_files/dashboard/index.html
+++ b/server_files/web_files/dashboard/index.html
@@ -45,7 +45,7 @@
 
     <div class="container col-sm-offset-3">
       <div class="row">
-        <textarea name="name" rows="32" id="log" class="form-control"></textarea>
+        <textarea autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" name="name" rows="32" id="log" class="form-control"></textarea>
       </div>
     </div>
     <div class="container col-sm-offset-3">
@@ -57,7 +57,7 @@
             <span class="input-group-btn">
               <button class="btn btn-default" type="button">Execute</button>
             </span>
-            <input type="text" class="form-control" id="command" name="Body" placeholder="command">
+            <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="text" class="form-control" id="command" name="Body" placeholder="command">
           </div>
         </form>
       </div>


### PR DESCRIPTION
Disable spell checking and autocorrection/autocaps on log and command
bar and autocompletion on the log. Might also reduce lag on browsers
which decide to point out NullPointerException isn't an English word.
