### PR TITLE
Made setport() check for undefined properties in addition to null

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -188,7 +188,7 @@ function setport() { // Enforcing server properties set by host
     //console.log(mcport);
     try {
 		var props = getServerProps(); // Get the original properties
-		if (props !== null) {
+		if ((typeof props !== "undefined") && (props !== null)) {
             var oldport = props.get('server-port');
 			// Here we set any minecraft server properties we need
 			fs.readFile('server.properties', 'utf8', function(err, data) {


### PR DESCRIPTION
This fixes the non-helpful error:

`[TypeError: Cannot read property 'get' of undefined]`

to be a bit more helpful and explicit

`Failed to get the server properties!`
