### PR TITLE
fix: Use volume for container's node_modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       DEBUG: "nodemc:*"
     volumes:
       - ./:/CORE
+      - /CORE/node_modules
     ports:
       - 8081:80
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,7 +7,13 @@ echo "running as '$(whoami)'"
 echo "running in '$(pwd)'"
 
 # This allows us to use image built node_modules, no yarn needed!
-echo "shadow mounting '/node_modules' -> $(pwd)/node_modules"
-ln -sv /node_modules $(pwd)/node_modules
+mkdir -p node_modules
+
+echo "shadow mounting '/node_modules/*' -> $(pwd)/node_modules/*"
+for f in /node_modules/*; do
+  ln -sv "$f" "$(pwd)$f";
+done
+
+#ln -sv /node_modules $(pwd)/node_modules
 
 yarn start


### PR DESCRIPTION
This PR changes `docker-compose.yml` to use a volume to ensure that the Docker image does not interfere with the host's `node_modules` directory, but still uses the prebuilt `node_modules` in the image.

Previously, the modules could not be installed on the host on Windows, as the `/CORE/node_modules/` directory would not be linked to the image's prebuilt modules and binaries built for Windows would conflict when `require`d inside the container. This impacts some editors that require modules to be installed locally for functionality, such as VS Code for ESlint.

In the `docker-compose.yml`, an empty volume is mounted at `/CORE/node_modules`. This ensures that the host's  node_modules` isn't affected by anything in the container, like the entrypoint script.

As a result of this, the `docker-entrypoint.sh` has been adapted to create symlinks for `/CORE/node_modules/* -> /node_modules/*`, rather than just linking the prebuilt `/node_modules/` directory directly, as this won't work if `/CORE/node_modules` already exists. It also creates `/CORE/node_modules` if it doesn't already exist for some reason.

I'm submitting this as a PR as I'm not sure whether there are better ways to avoid touching the files on the host. The `.dockerignore` doesn't help in this case, since it only applies while the container is built from the Dockerfile, not when a volume is mounted.

/essay